### PR TITLE
Do not delete entries without a color

### DIFF
--- a/js/popup.js
+++ b/js/popup.js
@@ -14,7 +14,7 @@ document.addEventListener('DOMContentLoaded', function() {
       var displayname=$("#"+i+"displayname").val();
       var color=$("#"+i+"color").val();
 
-      if(account && role && displayname && color){
+      if(account && role && displayname){
         theCookieValueObj.rl.push({
           a:account,
           r:role,


### PR DESCRIPTION
Color does not require a value. In fact, when you switch roles, the "black" right-most color actually uses an empty color value. This fix prevents accidental deletion of those roles.

In addition to that, there are two other things that I can create PRs for if you agree with these proposals:
- `theCookieValueObj.bn` is only defined if you are assuming another role, resulting in that text saying "For user undefined @ _account_.". I suggest just deleting [this line](https://github.com/derBroBro/aws-role-editor/blob/c378b46b5632fe10e7078e28d9fca26ca7705f3e/js/popup.js#L57).
- Making the popup slightly larger to make it easier to edit.
- Adding a color preview box, like the one you see in the AWS form.
- Maybe adding a color picker, if I can find a good one.
- Adding a delete button or "x" link.
- Adding drag handlers to reorder.

If you agree with these, I can submit PRs.
